### PR TITLE
Update generate-airprint.py to Python3

### DIFF
--- a/root/root/airprint-generate.py
+++ b/root/root/airprint-generate.py
@@ -107,10 +107,10 @@ class AirPrintGenerate(object):
         self.directory = directory
         self.prefix = prefix
         self.adminurl = adminurl
-        
+
         if self.user:
             cups.setUser(self.user)
-    
+
     def generate(self):
         if not self.host:
             conn = cups.Connection()
@@ -118,9 +118,9 @@ class AirPrintGenerate(object):
             if not self.port:
                 self.port = 631
             conn = cups.Connection(self.host, self.port)
-            
+
         printers = conn.getPrinters()
-        
+
         for p, v in printers.items():
             if v['printer-is-shared']:
                 attrs = conn.getPrinterAttributes(p)
@@ -148,17 +148,17 @@ class AirPrintGenerate(object):
                   rp = uri.path
                 else:
                   rp = uri[2]
-                
+
                 re_match = re.match(r'^//(.*):(\d+)(/.*)', rp)
                 if re_match:
                   rp = re_match.group(3)
-                
+
                 #Remove leading slashes from path
                 #TODO XXX FIXME I'm worried this will match broken urlparse
                 #results as well (for instance if they don't include a port)
                 #the xml would be malform'd either way
                 rp = re.sub(r'^/+', '', rp)
-                
+
                 path = Element('txt-record')
                 path.text = 'rp=%s' % (rp)
                 service.append(path)
@@ -212,12 +212,12 @@ class AirPrintGenerate(object):
                     admin = Element('txt-record')
                     admin.text = 'adminurl=%s' % (v['printer-uri-supported'])
                     service.append(admin)
-                
+
                 fname = '%s%s.service' % (self.prefix, p)
-                
+
                 if self.directory:
                     fname = os.path.join(self.directory, fname)
-                
+
                 f = open(fname, 'w')
 
                 if etree:
@@ -229,7 +229,7 @@ class AirPrintGenerate(object):
                     doc.insertBefore(dt, doc.documentElement)
                     doc.writexml(f)
                 f.close()
-                
+
                 if self.verbose:
                     sys.stderr.write('Created: %s%s' % (fname, os.linesep))
 
@@ -252,18 +252,18 @@ if __name__ == '__main__':
         default='AirPrint-')
     parser.add_option('-a', '--admin', action="store_true", dest="adminurl",
         help="Include the printer specified uri as the adminurl")
-    
+
     (options, args) = parser.parse_args()
-    
+
     # TODO XXX FIXME -- if cups login required, need to add
     # air=username,password
     from getpass import getpass
     cups.setPasswordCB(getpass)
-    
+
     if options.directory:
         if not os.path.exists(options.directory):
             os.mkdir(options.directory)
-    
+
     apg = AirPrintGenerate(
         user=options.username,
         host=options.hostname,
@@ -273,5 +273,5 @@ if __name__ == '__main__':
         prefix=options.prefix,
         adminurl=options.adminurl,
     )
-    
+
     apg.generate()

--- a/root/root/airprint-generate.py
+++ b/root/root/airprint-generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Copyright (c) 2010 Timothy J Fontaine <tjfontaine@atxconsulting.com>
@@ -22,9 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import cups, os, optparse, re, urlparse
+import cups, os, optparse, re, urllib.parse
 import os.path
-from StringIO import StringIO
+from io import StringIO
 
 from xml.dom.minidom import parseString
 from xml.dom import minidom
@@ -43,7 +43,7 @@ except:
             from elementtree import Element, ElementTree, tostring
             etree = None
         except:
-            raise 'Failed to find python libxml or elementtree, please install one of those or use python >= 2.5'
+            raise Exception('Failed to find python libxml or elementtree, please install one of those or use python >= 2.5')
 
 XML_TEMPLATE = """<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
@@ -121,10 +121,10 @@ class AirPrintGenerate(object):
 
         printers = conn.getPrinters()
 
-        for p, v in printers.items():
+        for p, v in list(printers.items()):
             if v['printer-is-shared']:
                 attrs = conn.getPrinterAttributes(p)
-                uri = urlparse.urlparse(v['printer-uri-supported'])
+                uri = urllib.parse.urlparse(v['printer-uri-supported'])
 
                 tree = ElementTree()
                 tree.parse(StringIO(XML_TEMPLATE.replace('\n', '').replace('\r', '').replace('\t', '')))


### PR DESCRIPTION
The Docker image installs Python3 but the script to create the Avahi service definitions is a Python2 one! I ran `2to3` on it and fixed the exception raising manually.